### PR TITLE
Changed the scope of all TGG testsuite launchers to 'test' source folder

### DIFF
--- a/Testsuite/.classpath
+++ b/Testsuite/.classpath
@@ -5,5 +5,6 @@
 	<classpathentry kind="src" path="test"/>
 	<classpathentry kind="src" path="xtend-gen"/>
 	<classpathentry kind="src" path="performance_src"/>
+	<classpathentry kind="src" path="test-bundles"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/Testsuite/Testsuite_Democles_CBC.launch
+++ b/Testsuite/Testsuite_Democles_CBC.launch
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.eclipse.jdt.junit.launchconfig">
     <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
-        <listEntry value="/Testsuite"/>
+        <listEntry value="/Testsuite/test"/>
     </listAttribute>
     <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
         <listEntry value="4"/>
@@ -11,7 +11,7 @@
         <mapEntry key="patternMatcher" value="Democles"/>
     </mapAttribute>
     <stringAttribute key="org.eclipse.debug.ui.ATTR_CAPTURE_IN_FILE" value="${workspace_loc:/Testsuite/results}/Testsuite_CBC_out_${current_date}.txt"/>
-    <stringAttribute key="org.eclipse.jdt.junit.CONTAINER" value="=Testsuite"/>
+    <stringAttribute key="org.eclipse.jdt.junit.CONTAINER" value="=Testsuite/test"/>
     <booleanAttribute key="org.eclipse.jdt.junit.KEEPRUNNING_ATTR" value="true"/>
     <stringAttribute key="org.eclipse.jdt.junit.TESTNAME" value=""/>
     <stringAttribute key="org.eclipse.jdt.junit.TEST_KIND" value="org.eclipse.jdt.junit.loader.junit4"/>

--- a/Testsuite/Testsuite_Democles_GLPK.launch
+++ b/Testsuite/Testsuite_Democles_GLPK.launch
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.eclipse.jdt.junit.launchconfig">
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
-<listEntry value="/Testsuite"/>
+<listEntry value="/Testsuite/test"/>
 </listAttribute>
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
 <listEntry value="4"/>
@@ -11,7 +11,7 @@
     <mapEntry key="patternMatcher" value="Democles"/>
 </mapAttribute>
 <stringAttribute key="org.eclipse.debug.ui.ATTR_CAPTURE_IN_FILE" value="${workspace_loc:/Testsuite/results}/Testsuite_GLPK_out_${current_date}.txt"/>
-<stringAttribute key="org.eclipse.jdt.junit.CONTAINER" value="=Testsuite"/>
+<stringAttribute key="org.eclipse.jdt.junit.CONTAINER" value="=Testsuite/test"/>
 <booleanAttribute key="org.eclipse.jdt.junit.KEEPRUNNING_ATTR" value="true"/>
 <stringAttribute key="org.eclipse.jdt.junit.TESTNAME" value=""/>
 <stringAttribute key="org.eclipse.jdt.junit.TEST_KIND" value="org.eclipse.jdt.junit.loader.junit4"/>

--- a/Testsuite/Testsuite_Democles_Gurobi.launch
+++ b/Testsuite/Testsuite_Democles_Gurobi.launch
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.eclipse.jdt.junit.launchconfig">
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
-<listEntry value="/Testsuite"/>
+<listEntry value="/Testsuite/test"/>
 </listAttribute>
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
 <listEntry value="4"/>
@@ -11,7 +11,7 @@
 <mapEntry key="patternMatcher" value="Democles"/>
 </mapAttribute>
 <stringAttribute key="org.eclipse.debug.ui.ATTR_CAPTURE_IN_FILE" value="${workspace_loc:/Testsuite/results}/Testsuite_Gurobi_out_${current_date}.txt"/>
-<stringAttribute key="org.eclipse.jdt.junit.CONTAINER" value="=Testsuite"/>
+<stringAttribute key="org.eclipse.jdt.junit.CONTAINER" value="=Testsuite/test"/>
 <booleanAttribute key="org.eclipse.jdt.junit.KEEPRUNNING_ATTR" value="false"/>
 <stringAttribute key="org.eclipse.jdt.junit.TESTNAME" value=""/>
 <stringAttribute key="org.eclipse.jdt.junit.TEST_KIND" value="org.eclipse.jdt.junit.loader.junit4"/>

--- a/Testsuite/Testsuite_Democles_MIPCL.launch
+++ b/Testsuite/Testsuite_Democles_MIPCL.launch
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.eclipse.jdt.junit.launchconfig">
     <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
-        <listEntry value="/Testsuite"/>
+        <listEntry value="/Testsuite/test"/>
     </listAttribute>
     <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
         <listEntry value="4"/>
@@ -11,7 +11,7 @@
         <mapEntry key="patternMatcher" value="Democles"/>
     </mapAttribute>
     <stringAttribute key="org.eclipse.debug.ui.ATTR_CAPTURE_IN_FILE" value="${workspace_loc:/Testsuite/results}/Testsuite_CBC_out_${current_date}.txt"/>
-    <stringAttribute key="org.eclipse.jdt.junit.CONTAINER" value="=Testsuite"/>
+    <stringAttribute key="org.eclipse.jdt.junit.CONTAINER" value="=Testsuite/test"/>
     <booleanAttribute key="org.eclipse.jdt.junit.KEEPRUNNING_ATTR" value="true"/>
     <stringAttribute key="org.eclipse.jdt.junit.TESTNAME" value=""/>
     <stringAttribute key="org.eclipse.jdt.junit.TEST_KIND" value="org.eclipse.jdt.junit.loader.junit4"/>

--- a/Testsuite/Testsuite_Democles_SAT4J.launch
+++ b/Testsuite/Testsuite_Democles_SAT4J.launch
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.eclipse.jdt.junit.launchconfig">
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
-<listEntry value="/Testsuite"/>
+<listEntry value="/Testsuite/test"/>
 </listAttribute>
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
 <listEntry value="4"/>
@@ -11,7 +11,7 @@
 	<mapEntry key="patternMatcher" value="Democles"/>
 </mapAttribute>
 <stringAttribute key="org.eclipse.debug.ui.ATTR_CAPTURE_IN_FILE" value="${workspace_loc:/Testsuite/results}/Testsuite_SAT4J_out_${current_date}.txt"/>
-<stringAttribute key="org.eclipse.jdt.junit.CONTAINER" value="=Testsuite"/>
+<stringAttribute key="org.eclipse.jdt.junit.CONTAINER" value="=Testsuite/test"/>
 <booleanAttribute key="org.eclipse.jdt.junit.KEEPRUNNING_ATTR" value="false"/>
 <stringAttribute key="org.eclipse.jdt.junit.TESTNAME" value=""/>
 <stringAttribute key="org.eclipse.jdt.junit.TEST_KIND" value="org.eclipse.jdt.junit.loader.junit4"/>

--- a/Testsuite/Testsuite_HiPE_CBC.launch
+++ b/Testsuite/Testsuite_HiPE_CBC.launch
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.eclipse.jdt.junit.launchconfig">
     <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
-        <listEntry value="/Testsuite"/>
+        <listEntry value="/Testsuite/test"/>
     </listAttribute>
     <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
         <listEntry value="4"/>
@@ -11,7 +11,7 @@
         <mapEntry key="patternMatcher" value="HiPE"/>
     </mapAttribute>
     <stringAttribute key="org.eclipse.debug.ui.ATTR_CAPTURE_IN_FILE" value="${workspace_loc:/Testsuite/results}/Testsuite_CBC_out_${current_date}.txt"/>
-    <stringAttribute key="org.eclipse.jdt.junit.CONTAINER" value="=Testsuite"/>
+    <stringAttribute key="org.eclipse.jdt.junit.CONTAINER" value="=Testsuite/test"/>
     <booleanAttribute key="org.eclipse.jdt.junit.KEEPRUNNING_ATTR" value="true"/>
     <stringAttribute key="org.eclipse.jdt.junit.TESTNAME" value=""/>
     <stringAttribute key="org.eclipse.jdt.junit.TEST_KIND" value="org.eclipse.jdt.junit.loader.junit4"/>

--- a/Testsuite/Testsuite_HiPE_GLPK.launch
+++ b/Testsuite/Testsuite_HiPE_GLPK.launch
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.eclipse.jdt.junit.launchconfig">
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
-<listEntry value="/Testsuite"/>
+<listEntry value="/Testsuite/test"/>
 </listAttribute>
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
 <listEntry value="4"/>
@@ -11,7 +11,7 @@
     <mapEntry key="patternMatcher" value="HiPE"/>
 </mapAttribute>
 <stringAttribute key="org.eclipse.debug.ui.ATTR_CAPTURE_IN_FILE" value="${workspace_loc:/Testsuite/results}/Testsuite_GLPK_out_${current_date}.txt"/>
-<stringAttribute key="org.eclipse.jdt.junit.CONTAINER" value="=Testsuite"/>
+<stringAttribute key="org.eclipse.jdt.junit.CONTAINER" value="=Testsuite/test"/>
 <booleanAttribute key="org.eclipse.jdt.junit.KEEPRUNNING_ATTR" value="true"/>
 <stringAttribute key="org.eclipse.jdt.junit.TESTNAME" value=""/>
 <stringAttribute key="org.eclipse.jdt.junit.TEST_KIND" value="org.eclipse.jdt.junit.loader.junit4"/>

--- a/Testsuite/Testsuite_HiPE_Gurobi.launch
+++ b/Testsuite/Testsuite_HiPE_Gurobi.launch
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.eclipse.jdt.junit.launchconfig">
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
-<listEntry value="/Testsuite"/>
+<listEntry value="/Testsuite/test"/>
 </listAttribute>
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
 <listEntry value="4"/>
@@ -11,7 +11,7 @@
     <mapEntry key="patternMatcher" value="HiPE"/>
 </mapAttribute>
 <stringAttribute key="org.eclipse.debug.ui.ATTR_CAPTURE_IN_FILE" value="${workspace_loc:/Testsuite/results}/Testsuite_Gurobi_out_${current_date}.txt"/>
-<stringAttribute key="org.eclipse.jdt.junit.CONTAINER" value="=Testsuite"/>
+<stringAttribute key="org.eclipse.jdt.junit.CONTAINER" value="=Testsuite/test"/>
 <booleanAttribute key="org.eclipse.jdt.junit.KEEPRUNNING_ATTR" value="false"/>
 <stringAttribute key="org.eclipse.jdt.junit.TESTNAME" value=""/>
 <stringAttribute key="org.eclipse.jdt.junit.TEST_KIND" value="org.eclipse.jdt.junit.loader.junit4"/>

--- a/Testsuite/Testsuite_HiPE_MIPCL.launch
+++ b/Testsuite/Testsuite_HiPE_MIPCL.launch
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.eclipse.jdt.junit.launchconfig">
     <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
-        <listEntry value="/Testsuite"/>
+        <listEntry value="/Testsuite/test"/>
     </listAttribute>
     <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
         <listEntry value="4"/>
@@ -11,7 +11,7 @@
         <mapEntry key="patternMatcher" value="HiPE"/>
     </mapAttribute>
     <stringAttribute key="org.eclipse.debug.ui.ATTR_CAPTURE_IN_FILE" value="${workspace_loc:/Testsuite/results}/Testsuite_CBC_out_${current_date}.txt"/>
-    <stringAttribute key="org.eclipse.jdt.junit.CONTAINER" value="=Testsuite"/>
+    <stringAttribute key="org.eclipse.jdt.junit.CONTAINER" value="=Testsuite/test"/>
     <booleanAttribute key="org.eclipse.jdt.junit.KEEPRUNNING_ATTR" value="true"/>
     <stringAttribute key="org.eclipse.jdt.junit.TESTNAME" value=""/>
     <stringAttribute key="org.eclipse.jdt.junit.TEST_KIND" value="org.eclipse.jdt.junit.loader.junit4"/>

--- a/Testsuite/Testsuite_HiPE_SAT4J.launch
+++ b/Testsuite/Testsuite_HiPE_SAT4J.launch
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.eclipse.jdt.junit.launchconfig">
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
-<listEntry value="/Testsuite"/>
+<listEntry value="/Testsuite/test"/>
 </listAttribute>
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
 <listEntry value="4"/>
@@ -11,7 +11,7 @@
 	<mapEntry key="patternMatcher" value="HiPE"/>
 </mapAttribute>
 <stringAttribute key="org.eclipse.debug.ui.ATTR_CAPTURE_IN_FILE" value="${workspace_loc:/Testsuite/results}/Testsuite_SAT4J_out_${current_date}.txt"/>
-<stringAttribute key="org.eclipse.jdt.junit.CONTAINER" value="=Testsuite"/>
+<stringAttribute key="org.eclipse.jdt.junit.CONTAINER" value="=Testsuite/test"/>
 <booleanAttribute key="org.eclipse.jdt.junit.KEEPRUNNING_ATTR" value="false"/>
 <stringAttribute key="org.eclipse.jdt.junit.TESTNAME" value=""/>
 <stringAttribute key="org.eclipse.jdt.junit.TEST_KIND" value="org.eclipse.jdt.junit.loader.junit4"/>

--- a/Testsuite/Testsuite_Viatra_CBC.launch
+++ b/Testsuite/Testsuite_Viatra_CBC.launch
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.eclipse.jdt.junit.launchconfig">
     <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
-        <listEntry value="/Testsuite"/>
+        <listEntry value="/Testsuite/test"/>
     </listAttribute>
     <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
         <listEntry value="4"/>
@@ -11,7 +11,7 @@
         <mapEntry key="patternMatcher" value="Viatra"/>
     </mapAttribute>
     <stringAttribute key="org.eclipse.debug.ui.ATTR_CAPTURE_IN_FILE" value="${workspace_loc:/Testsuite/results}/Testsuite_CBC_out_${current_date}.txt"/>
-    <stringAttribute key="org.eclipse.jdt.junit.CONTAINER" value="=Testsuite"/>
+    <stringAttribute key="org.eclipse.jdt.junit.CONTAINER" value="=Testsuite/test"/>
     <booleanAttribute key="org.eclipse.jdt.junit.KEEPRUNNING_ATTR" value="true"/>
     <stringAttribute key="org.eclipse.jdt.junit.TESTNAME" value=""/>
     <stringAttribute key="org.eclipse.jdt.junit.TEST_KIND" value="org.eclipse.jdt.junit.loader.junit4"/>

--- a/Testsuite/Testsuite_Viatra_GLPK.launch
+++ b/Testsuite/Testsuite_Viatra_GLPK.launch
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.eclipse.jdt.junit.launchconfig">
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
-<listEntry value="/Testsuite"/>
+<listEntry value="/Testsuite/test"/>
 </listAttribute>
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
 <listEntry value="4"/>
@@ -11,7 +11,7 @@
     <mapEntry key="patternMatcher" value="Viatra"/>
 </mapAttribute>
 <stringAttribute key="org.eclipse.debug.ui.ATTR_CAPTURE_IN_FILE" value="${workspace_loc:/Testsuite/results}/Testsuite_GLPK_out_${current_date}.txt"/>
-<stringAttribute key="org.eclipse.jdt.junit.CONTAINER" value="=Testsuite"/>
+<stringAttribute key="org.eclipse.jdt.junit.CONTAINER" value="=Testsuite/test"/>
 <booleanAttribute key="org.eclipse.jdt.junit.KEEPRUNNING_ATTR" value="true"/>
 <stringAttribute key="org.eclipse.jdt.junit.TESTNAME" value=""/>
 <stringAttribute key="org.eclipse.jdt.junit.TEST_KIND" value="org.eclipse.jdt.junit.loader.junit4"/>

--- a/Testsuite/Testsuite_Viatra_Gurobi.launch
+++ b/Testsuite/Testsuite_Viatra_Gurobi.launch
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.eclipse.jdt.junit.launchconfig">
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
-<listEntry value="/Testsuite"/>
+<listEntry value="/Testsuite/test"/>
 </listAttribute>
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
 <listEntry value="4"/>
@@ -11,7 +11,7 @@
     <mapEntry key="patternMatcher" value="Viatra"/>
 </mapAttribute>
 <stringAttribute key="org.eclipse.debug.ui.ATTR_CAPTURE_IN_FILE" value="${workspace_loc:/Testsuite/results}/Testsuite_Gurobi_out_${current_date}.txt"/>
-<stringAttribute key="org.eclipse.jdt.junit.CONTAINER" value="=Testsuite"/>
+<stringAttribute key="org.eclipse.jdt.junit.CONTAINER" value="=Testsuite/test"/>
 <booleanAttribute key="org.eclipse.jdt.junit.KEEPRUNNING_ATTR" value="false"/>
 <stringAttribute key="org.eclipse.jdt.junit.TESTNAME" value=""/>
 <stringAttribute key="org.eclipse.jdt.junit.TEST_KIND" value="org.eclipse.jdt.junit.loader.junit4"/>

--- a/Testsuite/Testsuite_Viatra_MIPCL.launch
+++ b/Testsuite/Testsuite_Viatra_MIPCL.launch
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.eclipse.jdt.junit.launchconfig">
     <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
-        <listEntry value="/Testsuite"/>
+        <listEntry value="/Testsuite/test"/>
     </listAttribute>
     <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
         <listEntry value="4"/>
@@ -11,7 +11,7 @@
         <mapEntry key="patternMatcher" value="Viatra"/>
     </mapAttribute>
     <stringAttribute key="org.eclipse.debug.ui.ATTR_CAPTURE_IN_FILE" value="${workspace_loc:/Testsuite/results}/Testsuite_CBC_out_${current_date}.txt"/>
-    <stringAttribute key="org.eclipse.jdt.junit.CONTAINER" value="=Testsuite"/>
+    <stringAttribute key="org.eclipse.jdt.junit.CONTAINER" value="=Testsuite/test"/>
     <booleanAttribute key="org.eclipse.jdt.junit.KEEPRUNNING_ATTR" value="true"/>
     <stringAttribute key="org.eclipse.jdt.junit.TESTNAME" value=""/>
     <stringAttribute key="org.eclipse.jdt.junit.TEST_KIND" value="org.eclipse.jdt.junit.loader.junit4"/>

--- a/Testsuite/Testsuite_Viatra_SAT4J.launch
+++ b/Testsuite/Testsuite_Viatra_SAT4J.launch
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.eclipse.jdt.junit.launchconfig">
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
-<listEntry value="/Testsuite"/>
+<listEntry value="/Testsuite/test"/>
 </listAttribute>
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
 <listEntry value="4"/>
@@ -11,7 +11,7 @@
 	<mapEntry key="patternMatcher" value="Viatra"/>
 </mapAttribute>
 <stringAttribute key="org.eclipse.debug.ui.ATTR_CAPTURE_IN_FILE" value="${workspace_loc:/Testsuite/results}/Testsuite_SAT4J_out_${current_date}.txt"/>
-<stringAttribute key="org.eclipse.jdt.junit.CONTAINER" value="=Testsuite"/>
+<stringAttribute key="org.eclipse.jdt.junit.CONTAINER" value="=Testsuite/test"/>
 <booleanAttribute key="org.eclipse.jdt.junit.KEEPRUNNING_ATTR" value="false"/>
 <stringAttribute key="org.eclipse.jdt.junit.TESTNAME" value=""/>
 <stringAttribute key="org.eclipse.jdt.junit.TEST_KIND" value="org.eclipse.jdt.junit.loader.junit4"/>

--- a/Testsuite/test-bundles/testsuite/ibex/intergate/AllIntegrateTests.java
+++ b/Testsuite/test-bundles/testsuite/ibex/intergate/AllIntegrateTests.java
@@ -15,5 +15,4 @@ import org.junit.runners.Suite.SuiteClasses;
 		testsuite.ibex.TerraceHouses2BlockSet.integrate.Multiplicity.class //
 })
 public class AllIntegrateTests {
-
 }


### PR DESCRIPTION
Changed the scope of all TGG testsuite launchers to the source folder 'test' so that independent test classes can be stored in separate source folders without being executed by that launchers