### PR TITLE
Adds separated PSF files for GT and TGG

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,16 @@
 # Tests for eMoflon::IBeX
-A collection of JUnit tests for [eMoflon::IBeX](https://github.com/eMoflon/emoflon-ibex) 
+A collection of JUnit tests for [eMoflon::IBeX](https://github.com/eMoflon/emoflon-ibex).
 
 ## Testsuites
-- `testsuites/TestsuiteGT`: JUnit tests for graph transformations (GT) via the Java API
-	generated from the GT rule specification
-- `testsuites/Testsuite`: JUnit tests for consistency checking, synchronization,
-	model generation with Triple Graph Grammars (TGGs)
+- `testsuites/TestsuiteGT`: JUnit tests for graph transformations (GT) via the Java API	generated from the GT rule specification.
+- `testsuites/Testsuite`: JUnit tests for consistency checking, synchronization, and model generation with Triple Graph Grammars (TGGs).
 
 ## How to run the tests
 1. Install [eMoflon::IBeX](https://github.com/eMoflon/emoflon-ibex).
-2. Go to ```File/Import.../Team/Team Project Set```, check URL and enter in and import this PSF file:
-	https://raw.githubusercontent.com/eMoflon/emoflon-ibex-tests/master/testProjectSet.psf
-3. Click on the projects `TestsuiteGT` and `Testsuite` by selecting one of the `*.launch` files.
+1. Go to ```File/Import.../Team/Team Project Set```, check URL and enter in and import **one** of these PSF files:
+	- https://raw.githubusercontent.com/eMoflon/emoflon-ibex-tests/master/testProjectSet-GT.psf (All **GT**-related projects tests)
+	- https://raw.githubusercontent.com/eMoflon/emoflon-ibex-tests/master/testProjectSet-TGG.psf (All **TGG**-related projects and tests)
+	- https://raw.githubusercontent.com/eMoflon/emoflon-ibex-tests/master/testProjectSet.psf (All projects and tests.)
+1. Click on the projects `TestsuiteGT` and `Testsuite` by selecting one of the `*.launch` files. Typically, you want to run one of these files:
+	- `TestsuiteGT_HiPE.launch`
+	- `Testsuite_HiPE_SAT4J.launch`

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ A collection of JUnit tests for [eMoflon::IBeX](https://github.com/eMoflon/emofl
 ## How to run the tests
 1. Install [eMoflon::IBeX](https://github.com/eMoflon/emoflon-ibex).
 1. Go to ```File/Import.../Team/Team Project Set```, check URL and enter in and import **one** of these PSF files:
-	- https://raw.githubusercontent.com/eMoflon/emoflon-ibex-tests/master/testProjectSet-GT.psf (All **GT**-related projects tests)
-	- https://raw.githubusercontent.com/eMoflon/emoflon-ibex-tests/master/testProjectSet-TGG.psf (All **TGG**-related projects and tests)
-	- https://raw.githubusercontent.com/eMoflon/emoflon-ibex-tests/master/testProjectSet.psf (All projects and tests.)
+	- All **GT**-related projects tests: https://raw.githubusercontent.com/eMoflon/emoflon-ibex-tests/master/testProjectSet-GT.psf
+	- All **TGG**-related projects and tests: https://raw.githubusercontent.com/eMoflon/emoflon-ibex-tests/master/testProjectSet-TGG.psf
+	- All projects and tests: https://raw.githubusercontent.com/eMoflon/emoflon-ibex-tests/master/testProjectSet.psf
 1. Click on the projects `TestsuiteGT` and `Testsuite` by selecting one of the `*.launch` files. Typically, you want to run one of these files:
 	- `TestsuiteGT_HiPE.launch`
 	- `Testsuite_HiPE_SAT4J.launch`

--- a/testProjectSet-GT.psf
+++ b/testProjectSet-GT.psf
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<psf version="2.0">
+<provider id="org.eclipse.egit.core.GitProvider">
+<project reference="1.0,https://github.com/eMoflon/benchmarx.git,master,core/Benchmarx"/>
+<project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,BPMN"/>
+<project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,BPMN-GraphTransformation"/>
+<project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,ClassMultipleInheritanceHierarchy"/>
+<project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,ClassMultipleInheritanceHierarchyGraphTransformation"/>
+<project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,EconomicsModel"/>
+<project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,FastEconomy"/>
+<project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,FerrymanProblem"/>
+<project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,FerrymanProblemGraphTransformation"/>
+<project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,GroupVotersModel"/>
+<project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,HospitalExample"/>
+<project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,HospitalTransformation"/>
+<project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,MetamodelInheritance"/>
+<project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,MetamodelInheritance2"/>
+<project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,MetamodelInheritance3"/>
+<project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,MetamodelInheritanceTransformation"/>
+<project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,SheRememberedCaterpillars"/>
+<project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,SheRememberedCaterpillarsGraphTransformation"/>
+<project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,SimpleChemistry"/>
+<project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,SimpleChemistryGraphTransformation"/>
+<project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,SimpleEconomy"/>
+<project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,SimpleEconomyGraphTransformation"/>
+<project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,SimpleFamilies"/>
+<project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,SimpleFamiliesGraphTransformation"/>
+<project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,SimpleFamiliesToSimplePersonsGraphTransformation"/>
+<project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,SimpleNetwork"/>
+<project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,SimpleNetworkGraphTransformation"/>
+<project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,SimpleNetworkGraphTransformation2"/>
+<project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,SimplePersons"/>
+<project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,SimplePersonsGraphTransformation"/>
+<project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,SlowEconomy"/>
+<project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,TestsuiteGT"/>
+<project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,Triangles"/>
+<project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,TrianglesGraphTransformation"/>
+<project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,VoterModelGraphTransformation"/>
+</provider>
+<workingSets editPageId="org.eclipse.jdt.ui.JavaWorkingSetPage" id="1544812018381_8" label="gt" name="gt">
+<item elementID="=ClassMultipleInheritanceHierarchyGraphTransformation" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
+<item elementID="=SimplePersonsGraphTransformation" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
+<item elementID="=TrianglesGraphTransformation" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
+<item elementID="=MetamodelInheritanceTransformation" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
+<item elementID="=SimpleNetworkGraphTransformation" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
+<item elementID="=SheRememberedCaterpillarsGraphTransformation" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
+<item elementID="=BPMN-GraphTransformation" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
+<item elementID="=FerrymanProblemGraphTransformation" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
+<item elementID="=SimpleFamiliesGraphTransformation" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
+<item elementID="=SimpleFamiliesToSimplePersonsGraphTransformation" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
+<item elementID="=FastEconomy" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
+<item elementID="=SimpleChemistryGraphTransformation" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
+<item elementID="=SimpleEconomyGraphTransformation" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
+<item elementID="=SlowEconomy" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
+<item elementID="=VoterModelGraphTransformation" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
+<item elementID="=SimpleNetworkGraphTransformation2" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
+<item elementID="=HospitalTransformation" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
+</workingSets>
+<workingSets editPageId="org.eclipse.jdt.ui.JavaWorkingSetPage" id="1611411207422_13" label="gt-metamodels" name="gt-metamodels">
+<item elementID="=SimpleNetwork" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
+<item elementID="=EconomicsModel" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
+<item elementID="=MetamodelInheritance" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
+<item elementID="=FerrymanProblem" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
+<item elementID="=MetamodelInheritance2" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
+<item elementID="=SheRememberedCaterpillars" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
+<item elementID="=SimplePersons" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
+<item elementID="=BPMN" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
+<item elementID="=ClassMultipleInheritanceHierarchy" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
+<item elementID="=Triangles" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
+<item elementID="=MetamodelInheritance3" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
+<item elementID="=SimpleFamilies" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
+<item elementID="=SimpleEconomy" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
+<item elementID="=SimpleChemistry" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
+<item elementID="=GroupVotersModel" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
+<item elementID="=HospitalExample" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
+</workingSets>
+<workingSets editPageId="org.eclipse.jdt.ui.JavaWorkingSetPage" id="1544812013290_7" label="testsuites" name="testsuites">
+<item elementID="=Benchmarx" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
+<item elementID="=TestsuiteGT" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
+</workingSets>
+</psf>

--- a/testProjectSet-TGG.psf
+++ b/testProjectSet-TGG.psf
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <psf version="2.0">
 <provider id="org.eclipse.egit.core.GitProvider">
+<project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,Algorithms"/>
 <project reference="1.0,https://github.com/eMoflon/benchmarx.git,master,core/Benchmarx"/>
 <project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,BenchmarxFamiliesToPersons"/>
 <project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,BlockCodeAdapter"/>
@@ -16,6 +17,7 @@
 <project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,CompanyToIT"/>
 <project reference="1.0,https://github.com/eMoflon/benchmarx.git,master,examples/gantttocpm/metamodels/CPM"/>
 <project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,Database"/>
+<project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,Documents"/>
 <project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,Express2UML"/>
 <project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,ExpressModel"/>
 <project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,ExtDocModel"/>
@@ -27,6 +29,7 @@
 <project reference="1.0,https://github.com/eMoflon/benchmarx.git,master,examples/familiestopersons/metamodels/Families"/>
 <project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,FamiliesToPersons_V0"/>
 <project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,FamiliesToPersons_V1"/>
+<project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,FamiliesWithSiblings"/>
 <project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,FeatureModelConcise"/>
 <project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,FeatureModelConciseToSafe"/>
 <project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,FeatureModelSafe"/>
@@ -50,6 +53,7 @@
 <project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,SimpleFamilies"/>
 <project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,SimpleJava"/>
 <project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,SimplePersons"/>
+<project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,Strategies"/>
 <project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,TerraceHouses"/>
 <project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,TerraceHouses2BlockSet"/>
 <project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,Testsuite"/>
@@ -129,5 +133,9 @@
 <item elementID="=BlockDiagram" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
 <item elementID="=MocaTree" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
 <item elementID="=ExpressModel" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
+<item elementID="=Algorithms" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
+<item elementID="=Documents" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
+<item elementID="=FamiliesWithSiblings" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
+<item elementID="=Strategies" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
 </workingSets>
 </psf>

--- a/testProjectSet-TGG.psf
+++ b/testProjectSet-TGG.psf
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <psf version="2.0">
 <provider id="org.eclipse.egit.core.GitProvider">
-<project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,Algorithms"/>
 <project reference="1.0,https://github.com/eMoflon/benchmarx.git,master,core/Benchmarx"/>
 <project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,BenchmarxFamiliesToPersons"/>
 <project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,BlockCodeAdapter"/>
@@ -9,19 +8,14 @@
 <project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,BlockDiagramCodeAdapter"/>
 <project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,BlockDiagramCodeAdapter_EdgeRules"/>
 <project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,BlockLanguage"/>
-<project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,BPMN"/>
-<project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,BPMN-GraphTransformation"/>
 <project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,ClassInheritanceHierarchy"/>
 <project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,ClassInhHier2DB"/>
 <project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,ClassMultipleInheritanceHierarchy"/>
-<project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,ClassMultipleInheritanceHierarchyGraphTransformation"/>
 <project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,Clazz2GlossarDoc"/>
 <project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,CompanyLanguage"/>
 <project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,CompanyToIT"/>
 <project reference="1.0,https://github.com/eMoflon/benchmarx.git,master,examples/gantttocpm/metamodels/CPM"/>
 <project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,Database"/>
-<project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,Documents"/>
-<project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,EconomicsModel"/>
 <project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,Express2UML"/>
 <project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,ExpressModel"/>
 <project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,ExtDocModel"/>
@@ -33,26 +27,15 @@
 <project reference="1.0,https://github.com/eMoflon/benchmarx.git,master,examples/familiestopersons/metamodels/Families"/>
 <project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,FamiliesToPersons_V0"/>
 <project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,FamiliesToPersons_V1"/>
-<project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,FamiliesWithSiblings"/>
-<project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,FastEconomy"/>
 <project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,FeatureModelConcise"/>
 <project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,FeatureModelConciseToSafe"/>
 <project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,FeatureModelSafe"/>
-<project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,FerrymanProblem"/>
-<project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,FerrymanProblemGraphTransformation"/>
 <project reference="1.0,https://github.com/eMoflon/benchmarx.git,master,examples/gantttocpm/metamodels/Gantt"/>
 <project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,GlossarDocumentation"/>
-<project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,GroupVotersModel"/>
-<project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,HospitalExample"/>
-<project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,HospitalTransformation"/>
 <project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,IBeXTGGGantt2CPM"/>
 <project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,ITLanguage"/>
 <project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,Java"/>
 <project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,Java2Doc"/>
-<project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,MetamodelInheritance"/>
-<project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,MetamodelInheritance2"/>
-<project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,MetamodelInheritance3"/>
-<project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,MetamodelInheritanceTransformation"/>
 <project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,MocaTree"/>
 <project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,MocaTreeToProcess"/>
 <project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,MoDiscoIbexTGG"/>
@@ -62,134 +45,27 @@
 <project reference="1.0,https://github.com/eMoflon/benchmarx.git,master,examples/familiestopersons/metamodels/Persons"/>
 <project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,ProcessCodeAdapter"/>
 <project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,ProcessDefinition"/>
-<project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,SheRememberedCaterpillars"/>
-<project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,SheRememberedCaterpillarsGraphTransformation"/>
-<project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,SimpleChemistry"/>
-<project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,SimpleChemistryGraphTransformation"/>
 <project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,SimpleClassInheritance"/>
 <project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,SimpleDoc"/>
-<project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,SimpleEconomy"/>
-<project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,SimpleEconomyGraphTransformation"/>
 <project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,SimpleFamilies"/>
-<project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,SimpleFamiliesGraphTransformation"/>
-<project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,SimpleFamiliesToSimplePersonsGraphTransformation"/>
 <project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,SimpleJava"/>
-<project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,SimpleNetwork"/>
-<project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,SimpleNetworkGraphTransformation"/>
-<project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,SimpleNetworkGraphTransformation2"/>
 <project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,SimplePersons"/>
-<project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,SimplePersonsGraphTransformation"/>
-<project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,SlowEconomy"/>
-<project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,Strategies"/>
 <project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,TerraceHouses"/>
 <project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,TerraceHouses2BlockSet"/>
 <project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,Testsuite"/>
-<project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,TestsuiteGT"/>
 <project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,TrainLanguage"/>
 <project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,TrainToVehicle"/>
-<project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,Triangles"/>
-<project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,TrianglesGraphTransformation"/>
 <project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,Types"/>
 <project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,UML"/>
 <project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,UML2"/>
 <project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,VehicleLanguage"/>
 <project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,VHDLModel"/>
 <project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,VHDLTGGCodeAdapter"/>
-<project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,VoterModelGraphTransformation"/>
 <project reference="1.0,https://github.com/eMoflon/emoflon-ibex-tests.git,master,WoodenBlockSet"/>
 </provider>
-<workingSets editPageId="org.eclipse.jdt.ui.JavaWorkingSetPage" id="1544822822193_7" label="all-metamodels" name="all-metamodels">
-<item elementID="=SimpleJava" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-<item elementID="=SimpleNetwork" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-<item elementID="=Strategies" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-<item elementID="=UML" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-<item elementID="=SheRememberedCaterpillars" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-<item elementID="=MetamodelInheritance2" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-<item elementID="=TrainLanguage" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-<item elementID="=ExtTypeModel" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-<item elementID="=ExtDocModel" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-<item elementID="=org.emoflon.express.ui" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-<item elementID="=SimpleDoc" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-<item elementID="=org.emoflon.express" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-<item elementID="=SimpleClassInheritance" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-<item elementID="=ClassInheritanceHierarchy" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-<item elementID="=TerraceHouses" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-<item elementID="=FeatureModelSafe" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-<item elementID="=GlossarDocumentation" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-<item elementID="=Documents" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-<item elementID="=FerrymanProblem" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-<item elementID="=FamiliesWithSiblings" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-<item elementID="=WoodenBlockSet" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-<item elementID="=ITLanguage" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-<item elementID="=FeatureModelConcise" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-<item elementID="=BlockLanguage" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-<item elementID="=BPMN" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-<item elementID="=ClassMultipleInheritanceHierarchy" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-<item elementID="=Database" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-<item elementID="=MetamodelInheritance3" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-<item elementID="=Persons" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-<item elementID="=BlockDiagram" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-<item elementID="=CPM" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-<item elementID="=EconomicsModel" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-<item elementID="=MetamodelInheritance" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-<item elementID="=GroupVotersModel" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-<item elementID="=Triangles" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-<item elementID="=SimpleFamilies" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-<item elementID="=SimpleEconomy" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-<item elementID="=org.emoflon.express.ide" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-<item elementID="=VehicleLanguage" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-<item elementID="=Families" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-<item elementID="=SimplePersons" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-<item elementID="=Algorithms" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-<item elementID="=HospitalExample" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-<item elementID="=VHDLModel" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-<item elementID="=CompanyLanguage" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-<item elementID="=Gantt" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-<item elementID="=ProcessDefinition" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-<item elementID="=MocaTree" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-<item elementID="=SimpleChemistry" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-</workingSets>
-<workingSets editPageId="org.eclipse.jdt.ui.JavaWorkingSetPage" id="1544812018381_8" label="gt" name="gt">
-<item elementID="=ClassMultipleInheritanceHierarchyGraphTransformation" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-<item elementID="=SimplePersonsGraphTransformation" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-<item elementID="=TrianglesGraphTransformation" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-<item elementID="=MetamodelInheritanceTransformation" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-<item elementID="=SimpleNetworkGraphTransformation" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-<item elementID="=SheRememberedCaterpillarsGraphTransformation" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-<item elementID="=BPMN-GraphTransformation" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-<item elementID="=FerrymanProblemGraphTransformation" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-<item elementID="=SimpleFamiliesGraphTransformation" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-<item elementID="=SimpleFamiliesToSimplePersonsGraphTransformation" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-<item elementID="=FastEconomy" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-<item elementID="=SimpleChemistryGraphTransformation" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-<item elementID="=SimpleEconomyGraphTransformation" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-<item elementID="=SlowEconomy" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-<item elementID="=VoterModelGraphTransformation" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-<item elementID="=SimpleNetworkGraphTransformation2" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-<item elementID="=HospitalTransformation" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-</workingSets>
-<workingSets editPageId="org.eclipse.jdt.ui.JavaWorkingSetPage" id="1611411207422_13" label="gt-metamodels" name="gt-metamodels">
-<item elementID="=SimpleNetwork" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-<item elementID="=EconomicsModel" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-<item elementID="=MetamodelInheritance" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-<item elementID="=FerrymanProblem" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-<item elementID="=MetamodelInheritance2" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-<item elementID="=SheRememberedCaterpillars" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-<item elementID="=SimplePersons" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-<item elementID="=BPMN" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-<item elementID="=ClassMultipleInheritanceHierarchy" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-<item elementID="=Triangles" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-<item elementID="=MetamodelInheritance3" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-<item elementID="=SimpleFamilies" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-<item elementID="=SimpleEconomy" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-<item elementID="=SimpleChemistry" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-<item elementID="=GroupVotersModel" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-<item elementID="=HospitalExample" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-</workingSets>
 <workingSets editPageId="org.eclipse.jdt.ui.JavaWorkingSetPage" id="1544812013290_7" label="testsuites" name="testsuites">
 <item elementID="=Benchmarx" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
 <item elementID="=Testsuite" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
-<item elementID="=TestsuiteGT" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>
 </workingSets>
 <workingSets editPageId="org.eclipse.jdt.ui.JavaWorkingSetPage" id="1544812007133_6" label="tgg" name="tgg">
 <item elementID="=Express2UML" factoryID="org.eclipse.jdt.ui.PersistableJavaElementFactory"/>


### PR DESCRIPTION
This PR adds separated PSF files for all GT and TGG tests (+ metamodels, ...).
Furthermore, the "default" PSF file (with all tests and metamodels, ...) got updated.
The documentation in `README.md` was extended.