### PR TITLE
Fixes a broken `org.hamcrest.core` dep in BlockDiagram and BlockLanguage

### DIFF
--- a/BlockDiagram/META-INF/MANIFEST.MF
+++ b/BlockDiagram/META-INF/MANIFEST.MF
@@ -25,7 +25,7 @@ Require-Bundle: org.eclipse.core.runtime,
  junit-platform-runner,
  junit-platform-suite-api,
  junit-vintage-engine,
- org.hamcrest.core,
+ org.hamcrest,
  org.opentest4j,
  org.apiguardian.api
 Bundle-ManifestVersion: 2

--- a/BlockLanguage/META-INF/MANIFEST.MF
+++ b/BlockLanguage/META-INF/MANIFEST.MF
@@ -26,7 +26,7 @@ Require-Bundle: org.eclipse.core.runtime,
  junit-platform-runner,
  junit-platform-suite-api,
  junit-vintage-engine,
- org.hamcrest.core,
+ org.hamcrest,
  org.opentest4j,
  org.apiguardian.api
 Bundle-ManifestVersion: 2


### PR DESCRIPTION
Closes #118.